### PR TITLE
Fixed Remote Control Service

### DIFF
--- a/BlinkStickClient.Base/DataModel/NotificationRemoteControl.cs
+++ b/BlinkStickClient.Base/DataModel/NotificationRemoteControl.cs
@@ -66,7 +66,7 @@ namespace BlinkStickClient.DataModel
                     e.Handled = true;
                 }
 
-                Regex r = new Regex(@"^\/api\/v1\/color/([A-Za-z\-\.0-9]+)/([a-zA-z0-9]+)$");
+                Regex r = new Regex(@"^\/api\/v1\/color\/([A-Za-z\-\.0-9]+)\/([a-zA-z0-9]+)[\/]*$");
 
                 Match m = r.Match(e.Context.Request.Url.AbsolutePath);
 


### PR DESCRIPTION
Fixed the Regex used to evaluate the URL in the Remote Control Service (the "/" were not escaped and it doesn't matter now if there is a "/" at the end or not)